### PR TITLE
fix(uploadFileToZenodo): header should be application/octet-stream

### DIFF
--- a/src/zenodo.js
+++ b/src/zenodo.js
@@ -134,25 +134,11 @@ const uploadFileToZenodo = async (
 
     const url = `${bucket_url}/${file_name}`;
 
-    let content_type = mime.contentType(file_name)
-      ? mime.contentType(file_name)
-      : 'text/plain';
-
-    if (content_type.includes('application/json')) {
-      /**
-       * zenodo declines json uploads with a 400 - BAD REQUEST,
-       * avoiding error by setting content type to plain text
-       *
-       * @see https://github.com/zenodraft/zenodraft/blob/main/src/lib/file/add.ts#L15-L18
-       * */
-      content_type = 'text/plain';
-    }
-
     let content_length = fs.statSync(file_path).size.toString();
 
     const headers = {
       Authorization: `token  ${access_token}`,
-      'Content-Type': content_type,
+      'Content-Type': 'application/octet-stream',
       'Content-Length': content_length,
     };
 


### PR DESCRIPTION
Following up on [this issue](https://github.com/megasanjay/upload-to-zenodo/issues/54), this PR changes the `uploadFileToZenodo` function to always use `application/octet-stream` instead of `text/plain` and other headers. The implementation resembles the one from [zenodraft](https://github.com/zenodraft/zenodraft/blob/ddb4b0159f62ffd2b95e99fe40ba4f4024d48e5b/src/lib/file/add.ts#L15-L22).

@megasanjay, a few questions came up when creating the pull request and following the steps in the README:
- [ ] `npm run test` is missing a `./wait` import. Where do I get it or am I running tests wrong?
- [ ] `npm run test` requires a github token as an environment variable. What kind of token do I need?
- [ ] `npm run build` entails a lot of changes. Am I missing some configuration or is this intended?

## Summary by Sourcery

Bug Fixes:
- Fix the content type header in the uploadFileToZenodo function to always use application/octet-stream instead of text/plain or other headers.

## Summary by Sourcery

Bug Fixes:
- Fix the content type header in the uploadFileToZenodo function to always use application/octet-stream instead of text/plain or other headers.